### PR TITLE
Fix Transform Bug

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -685,7 +685,6 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # if the path changes, we want to remove any transforms related information. The user should
       # reselect the transforms file they wish to use with the 2D images.
       if self.customParamNode.transformsFilePath:
-        self.customParamNode.transformsFilePath = ""
         self.customParamNode.sequenceNodeTransforms = None
 
       if self.selector2DImagesFolder.currentPath == '':


### PR DESCRIPTION
### Description

This PR intends to add the following functionality:
     When reloading a new data set, the transform file tab should open the folder that the previous transform file was in.

### Testing

Was tested on Slicer 5.6.2 (Windows 11)
