### PR TITLE
Center Cine Images on Segmentation

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1501,6 +1501,14 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                                  self.customParamNode.sequenceNodeTransforms,
                                  self.customParamNode.opacity,
                                  self.customParamNode.overlayAsOutline)
+      # center images on segmentation
+      labelmap = slicer.mrmlScene.GetNodesByClass('vtkMRMLLabelMapVolumeNode').GetItemAsObject(0)
+      seg = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLSegmentationNode')
+      slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(labelmap, seg)
+      center = seg.GetSegmentCenterRAS(seg.GetSegmentation().GetNthSegmentID(0))
+      for name in layoutManager.sliceViewNames():
+        sliceNode = slicer.mrmlScene.GetNodeByID(f'vtkMRMLSliceNode{name}')
+        sliceNode.JumpSlice(center[0], center[1], center[2])
     
     self.applyTransformButton.enabled = False
 


### PR DESCRIPTION
### Description

This PR makes the following changes:
- By default, display the slice of cine images which pass through the center of mass of the segmentation.
- This behaviour is also replicated when the 'stop' button is pressed

### Testing

This change was tested using Slicer 5.6.2 on Windows