### PR TITLE
Clear Transforms File Selector

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1215,6 +1215,9 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     if self.customParamNode.sequenceBrowserNode:
       self.customParamNode.sequenceBrowserNode.SetPlaybackActive(False)
       self.customParamNode.sequenceBrowserNode.SetSelectedItemNumber(0)
+    
+    self.selectorTransformsFile.currentPath = ''
+    self.updateParameterNodeFromGUI("applyTransformsButton", "clicked")
     self.playbackSpeedBox.value = 5.0
     self.overlayOutlineOnlyBox.checked = True
     self.opacitySlider.value = 1


### PR DESCRIPTION
### Description

This PR intends to make the following changes:

- Clear the transforms file selector when the reset button is pressed

### Testing

Tested on Windows with Slicer 5.6.2