### PR TITLE
Fix Static Mask Bugs

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1520,6 +1520,8 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       seg = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLSegmentationNode')
       slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(labelmap, seg)
       center = seg.GetSegmentCenterRAS(seg.GetSegmentation().GetNthSegmentID(0))
+      slicer.modules.segmentations.logic().ExportAllSegmentsToLabelmapNode(seg, labelmap)
+      slicer.mrmlScene.RemoveNode(seg)
       for name in layoutManager.sliceViewNames():
         sliceNode = slicer.mrmlScene.GetNodeByID(f'vtkMRMLSliceNode{name}')
         sliceNode.JumpSlice(center[0], center[1], center[2])


### PR DESCRIPTION
### Description

This PR intends to make the following changes:

- Fix a static mask issue, visible during playback
- Also fix a similar static mask issue that occurs when "Reset All" or "X" buttons are clicked.

### Testing

Tested on Windows 11 using Slicer 5.6.2