### PR TITLE
Support dicom files

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -892,21 +892,24 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             struct = structSelectorComboBox.currentText
             dicomPath = dicomPathSelector.currentPath
             outputPath = outputPathSelector.currentPath
+            structures = [struct]
             segmentationPath = os.path.join(outputPath, 'mask_' + struct + '.nii.gz')
-            dcmrtstruct2nii(currentPath, dicomPath,outputPath)
+            dcmrtstruct2nii(rtstruct_file=currentPath,dicom_file=dicomPath,output_path=outputPath, structures=structures)
             self.selector3DSegmentation.currentPath = segmentationPath
             currentPath = segmentationPath
             structSelectorDialog.hide()
         structSelectorDialogLayout = qt.QFormLayout()
         structSelectorComboBox = qt.QComboBox()
         structSelectorComboBox.addItems(structs)
-        structSelectorDialogLayout.addRow("Select the structure to load", structSelectorComboBox)
+        structSelectorDialogLayout.addRow("Select the target segmentation:", structSelectorComboBox)
         dicomPathSelector = ctk.ctkPathLineEdit()
         dicomPathSelector.filters = ctk.ctkPathLineEdit.Dirs
-        structSelectorDialogLayout.addRow("Select the path to the DICOM files", dicomPathSelector)
+        structSelectorDialogLayout.addRow("DICOM images directory", dicomPathSelector)
         outputPathSelector = ctk.ctkPathLineEdit()
         outputPathSelector.filters = ctk.ctkPathLineEdit.Dirs
-        structSelectorDialogLayout.addRow("Select the path to the output structs", outputPathSelector)
+        structSelectorDialogLayout.addRow("Output segmentation directory", outputPathSelector)
+        structSelectorDialogLayout.addRow("Note: DICOM RT-STRUCT files are not directly loadable. Please provide the paths below to convert the segmentation into a loadable format.")
+        
         
         okButton = qt.QPushButton("OK")
         

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -894,11 +894,19 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           outputPath = outputPathSelector.currentPath
           structures = [structure]
           segmentationPath = os.path.join(outputPath, 'mask_' + structure + '.nii.gz')
-          dcmrtstruct2nii(rtstruct_file=currentPath,dicom_file=dicomPath,output_path=outputPath, structures=structures)
-          self.selector3DSegmentation.currentPath = segmentationPath
-          currentPath = segmentationPath
-          structSelectorDialog.accept()
-          structSelectorDialog.hide()
+          try:
+            dcmrtstruct2nii(rtstruct_file=currentPath,dicom_file=dicomPath,output_path=outputPath, structures=structures)
+            self.selector3DSegmentation.currentPath = segmentationPath
+            currentPath = segmentationPath
+          except Exception as e:
+            slicer.util.warningDisplay(f"Failed to convert {fileName} to a loadable format.\n{e}",
+                                        "Failed to Convert File")
+            self.customParamNode.path3DSegmentation = ""
+            self.selector3DSegmentation.currentPath = ""
+            return
+          finally:
+            structSelectorDialog.accept()
+            structSelectorDialog.hide()
         structSelectorDialogLayout = qt.QFormLayout()
         structSelectorComboBox = qt.QComboBox()
         structSelectorComboBox.addItems(structs)

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -854,12 +854,12 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
           from dcmrtstruct2nii import dcmrtstruct2nii, list_rt_structs
         except ModuleNotFoundError:
-          if slicer.util.confirmOkCancelDisplay("The dcmrtstruct2nii module is required to load DICOM RT files."
-                                    "Please install it by clicking OK button", "Missing Python packages"):
+          if slicer.util.confirmOkCancelDisplay("To load a DICOM RT structure, the dcmrtstruct2nii module is required."
+                                    "Please click 'OK' to install it", "Missing Python packages"):
             messageBox = qt.QMessageBox()
             messageBox.setIcon(qt.QMessageBox.Information)
             messageBox.setWindowTitle("Package Installation")
-            messageBox.setText("Installing 'dcmrtstruct2nii' package...")
+            messageBox.setText("Installing 'dcmrtstruct2nii'...")
             messageBox.setStandardButtons(qt.QMessageBox.NoButton)
             messageBox.show()
             slicer.app.processEvents()

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -889,11 +889,11 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # show a dialog to select the struct and path to dicom
         def onOK():
             nonlocal currentPath
-            struct = structSelectorComboBox.currentText
+            structure = structSelectorComboBox.currentText
             dicomPath = dicomPathSelector.currentPath
             outputPath = outputPathSelector.currentPath
-            structures = [struct]
-            segmentationPath = os.path.join(outputPath, 'mask_' + struct + '.nii.gz')
+            structures = [structure]
+            segmentationPath = os.path.join(outputPath, 'mask_' + structure + '.nii.gz')
             dcmrtstruct2nii(rtstruct_file=currentPath,dicom_file=dicomPath,output_path=outputPath, structures=structures)
             self.selector3DSegmentation.currentPath = segmentationPath
             currentPath = segmentationPath

--- a/Track/Track.py
+++ b/Track/Track.py
@@ -917,7 +917,7 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         outputPathSelector = ctk.ctkPathLineEdit()
         outputPathSelector.filters = ctk.ctkPathLineEdit.Dirs
         structSelectorDialogLayout.addRow("Output segmentation directory", outputPathSelector)
-        structSelectorDialogLayout.addWidget(qt.QLabel("Note: DICOM RT-STRUCT files are not directly loadable. Please provide the paths below to convert the segmentation into a loadable format."))
+        structSelectorDialogLayout.addWidget(qt.QLabel("Note: DICOM RT-STRUCT files are not directly loadable. Please provide the paths above to convert the segmentation into a loadable format."))
         
         
         okButton = qt.QPushButton("OK")

--- a/Track/utils/TrackLogic.py
+++ b/Track/utils/TrackLogic.py
@@ -102,7 +102,9 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       self.clearSliceForegrounds()
 
     return imagesSequenceNode, False
-
+  def createStructFromDCM(self, path2RTSTRUCT, path2DCM, path2Output):
+    from dcmrtstruct2nii import dcmrtstruct2nii
+    dcmrtstruct2nii(path2RTSTRUCT, path2DCM, path2Output)
   def getColumnNamesFromTransformsInput(self, filepath):
       
     fileName = os.path.basename(filepath)

--- a/Track/utils/TrackLogic.py
+++ b/Track/utils/TrackLogic.py
@@ -102,9 +102,7 @@ class TrackLogic(ScriptedLoadableModuleLogic):
       self.clearSliceForegrounds()
 
     return imagesSequenceNode, False
-  def createStructFromDCM(self, path2RTSTRUCT, path2DCM, path2Output):
-    from dcmrtstruct2nii import dcmrtstruct2nii
-    dcmrtstruct2nii(path2RTSTRUCT, path2DCM, path2Output)
+
   def getColumnNamesFromTransformsInput(self, filepath):
       
     fileName = os.path.basename(filepath)


### PR DESCRIPTION

This change is to support Dicome Files by allow user to select the mask and extract the mask from the dicom files 
automatically. It will only extract the selected mask to save on process time and storage.
Trello
https://trello.com/c/aV2bniwQ/8-high-priority-support-loading-of-dicom-structures-loading-dcm-structure-found-with-folder-dcmstructlung4d
Here is the demo (this is unlisted so only people with the link can view)
https://youtu.be/s9YfhXYzAOs
