### PR TITLE
Clear Columns on Reset

### DIFF
--- a/Track/Track.py
+++ b/Track/Track.py
@@ -1437,6 +1437,12 @@ class TrackWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     
     self.selectorTransformsFile.currentPath = ''
     self.updateParameterNodeFromGUI("applyTransformsButton", "clicked")
+    self.columnXSelector.clear()
+    self.columnXSelector.enabled = False
+    self.columnYSelector.clear()
+    self.columnYSelector.enabled = False
+    self.columnZSelector.clear()
+    self.columnZSelector.enabled = False
     self.playbackSpeedBox.value = 5.0
     self.overlayOutlineOnlyBox.checked = True
     self.opacitySlider.value = 1


### PR DESCRIPTION
### Description

This PR aims to ensure that the 'Translation' column selectors are cleared when the 'Reset All' button is pressed.

### Testing

Tested on Slicer 5.6.2 using Windows 11